### PR TITLE
Problem Response

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+# inspired by https://github.com/mvdan/github-actions-golang
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "*"
+
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go: [1.13.x, 1.14.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: true
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Test
         run: go test -v ./...
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.27
+          only-new-issues: true

--- a/api/details.go
+++ b/api/details.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/segmentio/ksuid"
 )
 
 // ctxKey represents the type of value for the context key
@@ -21,6 +23,23 @@ type Details struct {
 	RequestPath string
 	Params      httprouter.Params
 	StatusCode  int
+}
+
+// setDetails adds the required Details into the given request's context. The returned request should then be used.
+func setDetails(r *http.Request, path string, params httprouter.Params) *http.Request {
+
+	d := Details{
+		Now:         time.Now(),
+		RequestID:   ksuid.New().String(), // TODO: Get from request to add some request tracing.
+		Method:      r.Method,
+		RequestPath: path,
+		Params:      params,
+	}
+
+	// Add details to the context, so other functions can access them.
+	ctx := context.WithValue(r.Context(), KeyDetails, &d)
+
+	return r.WithContext(ctx)
 }
 
 // getDetails returns any Details found within the http.Request, or nil

--- a/api/requestresponse.go
+++ b/api/requestresponse.go
@@ -108,16 +108,16 @@ func WithType(t string) ProblemExtra {
 }
 
 // WithDetail allows the detail field to be added to the problem response.
-func WithDetail(detail string) ProblemExtra {
+func WithDetail(d string) ProblemExtra {
 	return func(p *problem) {
-		p.fields["detail"] = detail
+		p.fields["detail"] = d
 	}
 }
 
 // WithInstance allows the instance field to be added to the problem response.
-func WithInstance(instance string) ProblemExtra {
+func WithInstance(i string) ProblemExtra {
 	return func(p *problem) {
-		p.fields["instance"] = instance
+		p.fields["instance"] = i
 	}
 }
 

--- a/api/requestresponse.go
+++ b/api/requestresponse.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/peterbourgon/mergemap"
 )
 
 // Decode should be used to convert the request's JSON body into the given v value.
@@ -65,69 +67,90 @@ func Redirect(w http.ResponseWriter, r *http.Request, url string, code int) {
 	http.Redirect(w, r, url, code)
 }
 
-type problemResponse struct {
-	Type     string `json:"type"`
-	Title    string `json:"title"`
-	Status   int    `json:"status"`
-	Detail   string `json:"detail,omitempty"`
-	Instance string `json:"instance,omitempty"`
-}
-
-// ProblemExtra provides a way to add extra information into the problem response.
-type ProblemExtra func(*problemResponse)
-
-// WithType allows the type field to be added to the problem response.
-func WithType(t string) ProblemExtra {
-	return func(r *problemResponse) {
-		r.Type = t
-	}
-}
-
-// WithDetail allows the detail field to be added to the problem response.
-func WithDetail(detail string) ProblemExtra {
-	return func(r *problemResponse) {
-		r.Detail = detail
-	}
-}
-
-// WithInstance allows the instance field to be added to the problem response.
-func WithInstance(instance string) ProblemExtra {
-	return func(r *problemResponse) {
-		r.Instance = instance
-	}
-}
-
-// Problem responds to HTTP request with a response that follows RFC 7807 (https://tools.ietf.org/html/rfc7807).
-// It should be used for error responses.
-func Problem(w http.ResponseWriter, r *http.Request, title string, code int, extras ...ProblemExtra) {
-
-	response := problemResponse{
-		Type:   "about:blank", // RFC 7807 defines this as the default type value.
-		Title:  title,
-		Status: code,
-	}
-
-	// Apply all extras to the response struct
-	for _, e := range extras {
-		e(&response)
-	}
-
-	// Set the correct content-type header, as defined by RFC 7807.
-	w.Header().Set("Content-Type", "application/problem+json")
-
-	Respond(w, r, code, response)
-}
-
 // NotFound replies to the request with an HTTP 404 not found error, using the problem response defined by RFC 7807.
 func NotFound(w http.ResponseWriter, r *http.Request, extras ...ProblemExtra) {
 	code := http.StatusNotFound
 	title := http.StatusText(code)
 
-	Problem(w, r, title, code, extras...)
+	Problem(w, r, title, title, code, extras...)
 }
 
 // Error replies to the request with the specified error message and HTTP code,
 // using the problem response defined by RFC 7807.
 func Error(w http.ResponseWriter, r *http.Request, err string, code int, extras ...ProblemExtra) {
-	Problem(w, r, err, code, extras...)
+	Problem(w, r, http.StatusText(code), err, code, extras...)
+}
+
+//
+// Problem
+//
+
+// problem is a wrapper around a map that is used to collect all fields required for a problem response in
+// accordance to RFC 7807. It implements the json Marshaler interface to define a custom json marshalling.
+type problem struct {
+	fields map[string]interface{}
+}
+
+// MarshalJSON implements the json Marshaler interface.
+func (p problem) MarshalJSON() ([]byte, error) {
+	// Use the default marshaller for nested fields map.
+	return json.Marshal(p.fields)
+}
+
+// ProblemExtra provides a way to add extra information into the problem response.
+type ProblemExtra func(*problem)
+
+// WithType allows the type field to be added to the problem response.
+func WithType(t string) ProblemExtra {
+	return func(p *problem) {
+		p.fields["type"] = t
+	}
+}
+
+// WithDetail allows the detail field to be added to the problem response.
+func WithDetail(detail string) ProblemExtra {
+	return func(p *problem) {
+		p.fields["detail"] = detail
+	}
+}
+
+// WithInstance allows the instance field to be added to the problem response.
+func WithInstance(instance string) ProblemExtra {
+	return func(p *problem) {
+		p.fields["instance"] = instance
+	}
+}
+
+// WithFields allows extra fields to be included in the problem response.
+// Any field keys that clash with those expected in the problem response will not be used.
+func WithFields(fields map[string]interface{}) ProblemExtra {
+	return func(p *problem) {
+		// merges extra fields into the existing fields,
+		// where a conflict will choose the value from the existing fields.
+		p.fields = mergemap.Merge(fields, p.fields)
+	}
+}
+
+// Problem responds to HTTP request with a response that follows RFC 7807 (https://tools.ietf.org/html/rfc7807).
+// It should be used for error responses.
+func Problem(w http.ResponseWriter, r *http.Request, title, detail string, code int, extras ...ProblemExtra) {
+
+	p := problem{
+		fields: map[string]interface{}{
+			"type":   "about:blank", // RFC 7807 defines this as the default type value.
+			"title":  title,
+			"detail": detail,
+			"status": code,
+		},
+	}
+
+	// Apply all extras to the response struct
+	for _, e := range extras {
+		e(&p)
+	}
+
+	// Set the correct content-type header, as defined by RFC 7807.
+	w.Header().Set("Content-Type", "application/problem+json")
+
+	Respond(w, r, code, p)
 }

--- a/api/requestresponse.go
+++ b/api/requestresponse.go
@@ -5,6 +5,12 @@ import (
 	"net/http"
 )
 
+// Decode should be used to convert the request's JSON body into the given v value.
+func Decode(w http.ResponseWriter, r *http.Request, v interface{}) error {
+	// FUTURE: Can handle different content types by looking at the request headers.
+	return json.NewDecoder(r.Body).Decode(v)
+}
+
 // Respond should be used to respond to a http request within a http handler.
 // Respond encodes any data passed in as JSON.
 // Respond also sets the status code of the response on the request details, so
@@ -17,8 +23,10 @@ func Respond(w http.ResponseWriter, r *http.Request, code int, data interface{})
 	// If we have data to respond with, encode it into JSON, and set the correct
 	// header. If we cannot encode, we'll return an Internal Server Error.
 	if data != nil {
-		// Set the correct header
-		w.Header().Set("Content-Type", "application/json")
+		// Set the content-type if not already set
+		if w.Header().Get("Content-Type") == "" {
+			w.Header().Set("Content-Type", "application/json")
+		}
 
 		// Marshal data into byte array
 		jsonData, err = json.Marshal(data)
@@ -57,8 +65,69 @@ func Redirect(w http.ResponseWriter, r *http.Request, url string, code int) {
 	http.Redirect(w, r, url, code)
 }
 
-// Decode should be used to convert the request's JSON body into the given v value.
-func Decode(w http.ResponseWriter, r *http.Request, v interface{}) error {
-	// FUTURE: Can handle different content types by looking at the request headers.
-	return json.NewDecoder(r.Body).Decode(v)
+type problemResponse struct {
+	Type     string `json:"type"`
+	Title    string `json:"title"`
+	Status   int    `json:"status"`
+	Detail   string `json:"detail,omitempty"`
+	Instance string `json:"instance,omitempty"`
+}
+
+// ProblemExtra provides a way to add extra information into the problem response.
+type ProblemExtra func(*problemResponse)
+
+// WithType allows the type field to be added to the problem response.
+func WithType(t string) ProblemExtra {
+	return func(r *problemResponse) {
+		r.Type = t
+	}
+}
+
+// WithDetail allows the detail field to be added to the problem response.
+func WithDetail(detail string) ProblemExtra {
+	return func(r *problemResponse) {
+		r.Detail = detail
+	}
+}
+
+// WithInstance allows the instance field to be added to the problem response.
+func WithInstance(instance string) ProblemExtra {
+	return func(r *problemResponse) {
+		r.Instance = instance
+	}
+}
+
+// Problem responds to HTTP request with a response that follows RFC 7807 (https://tools.ietf.org/html/rfc7807).
+// It should be used for error 	responses.
+func Problem(w http.ResponseWriter, r *http.Request, title string, code int, extras ...ProblemExtra) {
+
+	response := problemResponse{
+		Type:   "about:blank", // RFC 7807 defines this as the default type value.
+		Title:  title,
+		Status: code,
+	}
+
+	// Apply all extras to the response struct
+	for _, e := range extras {
+		e(&response)
+	}
+
+	// Set the correct content-type header, as defined by RFC 7807.
+	w.Header().Set("Content-Type", "application/problem+json")
+
+	Respond(w, r, code, response)
+}
+
+// NotFound replies to the request with an HTTP 404 not found error, using the problem response defined by RFC 7807.
+func NotFound(w http.ResponseWriter, r *http.Request, extras ...ProblemExtra) {
+	code := http.StatusNotFound
+	title := http.StatusText(code)
+
+	Problem(w, r, title, code, extras...)
+}
+
+// Error replies to the request with the specified error message and HTTP code,
+// using the problem response defined by RFC 7807.
+func Error(w http.ResponseWriter, r *http.Request, err string, code int, extras ...ProblemExtra) {
+	Problem(w, r, err, code, extras...)
 }

--- a/api/requestresponse.go
+++ b/api/requestresponse.go
@@ -98,7 +98,7 @@ func WithInstance(instance string) ProblemExtra {
 }
 
 // Problem responds to HTTP request with a response that follows RFC 7807 (https://tools.ietf.org/html/rfc7807).
-// It should be used for error 	responses.
+// It should be used for error responses.
 func Problem(w http.ResponseWriter, r *http.Request, title string, code int, extras ...ProblemExtra) {
 
 	response := problemResponse{

--- a/api/requestresponse_test.go
+++ b/api/requestresponse_test.go
@@ -56,8 +56,10 @@ func TestProblemResponse(t *testing.T) {
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
 	d := getDetails(r)
-	is.True(d != nil)                         // details exist.
-	is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+	is.True(d != nil) // details exist.
+	if d != nil {
+		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+	}
 }
 
 func TestProblemResponseWithExtras(t *testing.T) {
@@ -100,8 +102,10 @@ func TestProblemResponseWithExtras(t *testing.T) {
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
 	d := getDetails(r)
-	is.True(d != nil)                         // details exist.
-	is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+	is.True(d != nil) // details exist.
+	if d != nil {
+		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+	}
 }
 
 func TestNotFoundResponse(t *testing.T) {
@@ -140,8 +144,10 @@ func TestNotFoundResponse(t *testing.T) {
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
 	d := getDetails(r)
-	is.True(d != nil)           // details exist.
-	is.Equal(d.StatusCode, 404) // status is set on details.
+	is.True(d != nil) // details exist.
+	if d != nil {
+		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+	}
 }
 
 func TestErrorResponse(t *testing.T) {
@@ -180,6 +186,8 @@ func TestErrorResponse(t *testing.T) {
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
 	d := getDetails(r)
-	is.True(d != nil)                                      // details exist.
-	is.Equal(d.StatusCode, http.StatusInternalServerError) // status is set on details.
+	is.True(d != nil) // details exist.
+	if d != nil {
+		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+	}
 }

--- a/api/requestresponse_test.go
+++ b/api/requestresponse_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/matryer/is"
+)
+
+func newRequest(method, path string, body io.Reader) (*http.Request, error) {
+	r, err := http.NewRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	r = setDetails(r, path, httprouter.Params{})
+	return r, nil
+}
+
+func TestProblemResponse(t *testing.T) {
+
+	is := is.New(t)
+
+	// Create a dummy request to pass to our problem response.
+	r, err := newRequest("GET", "/teapot", nil)
+	is.NoErr(err)
+
+	// Create a response recorder, which satisfied http.ResponseWriter, to record the response.
+	rr := httptest.NewRecorder()
+
+	// Respond with a problem.
+	Problem(rr, r, "The problem is that I'm a teapot", http.StatusTeapot)
+
+	// Check things.
+	is.Equal(rr.Code, http.StatusTeapot) // status code is teapot.
+
+	type body struct {
+		Type   string `json:"type"`
+		Title  string `json:"title"`
+		Status int    `json:"status"`
+	}
+
+	expectedBody := body{
+		Type:   "about:blank",
+		Title:  "The problem is that I'm a teapot",
+		Status: http.StatusTeapot,
+	}
+	var actualBody body
+	err = json.Unmarshal(rr.Body.Bytes(), &actualBody)
+	is.NoErr(err)                      // actual body is json.
+	is.Equal(actualBody, expectedBody) // response body is correct.
+
+	d := getDetails(r)
+	is.True(d != nil)                         // details exist.
+	is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+}
+
+func TestProblemResponseWithExtras(t *testing.T) {
+
+	is := is.New(t)
+
+	// Create a dummy request to pass to our problem response.
+	r, err := newRequest("GET", "/teapot", nil)
+	is.NoErr(err)
+
+	// Create a response recorder, which satisfied http.ResponseWriter, to record the response.
+	rr := httptest.NewRecorder()
+
+	// Respond with a problem.
+	Problem(rr, r, "The problem is that I'm a teapot", http.StatusTeapot, WithType("https://example.net/validation-error"), WithDetail("I need a handle."), WithInstance("BROWN-BETTY"))
+
+	// Check things.
+	is.Equal(rr.Code, http.StatusTeapot) // status code is teapot.
+
+	type body struct {
+		Type     string `json:"type"`
+		Title    string `json:"title"`
+		Status   int    `json:"status"`
+		Detail   string `json:"detail"`
+		Instance string `json:"instance"`
+	}
+
+	expectedBody := body{
+		Type:     "https://example.net/validation-error",
+		Title:    "The problem is that I'm a teapot",
+		Status:   http.StatusTeapot,
+		Detail:   "I need a handle.",
+		Instance: "BROWN-BETTY",
+	}
+	var actualBody body
+	err = json.Unmarshal(rr.Body.Bytes(), &actualBody)
+	is.NoErr(err)                      // actual body is json.
+	is.Equal(actualBody, expectedBody) // response body is correct.
+
+	d := getDetails(r)
+	is.True(d != nil)                         // details exist.
+	is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+}
+
+func TestNotFoundResponse(t *testing.T) {
+
+	is := is.New(t)
+
+	// Create a dummy request to pass to our problem response.
+	r, err := newRequest("GET", "/not-found", nil)
+	is.NoErr(err)
+
+	// Create a response recorder, which satisfied http.ResponseWriter, to record the response.
+	rr := httptest.NewRecorder()
+
+	// Respond with not found.
+	NotFound(rr, r)
+
+	// Check things.
+	is.Equal(rr.Code, 404) // status code is correct.
+
+	type body struct {
+		Type   string `json:"type"`
+		Title  string `json:"title"`
+		Status int    `json:"status"`
+	}
+
+	expectedBody := body{
+		Type:   "about:blank",
+		Title:  "Not Found",
+		Status: 404,
+	}
+	var actualBody body
+	err = json.Unmarshal(rr.Body.Bytes(), &actualBody)
+	is.NoErr(err)                      // actual body is json.
+	is.Equal(actualBody, expectedBody) // response body is correct.
+
+	d := getDetails(r)
+	is.True(d != nil)           // details exist.
+	is.Equal(d.StatusCode, 404) // status is set on details.
+}
+
+func TestErrorResponse(t *testing.T) {
+
+	is := is.New(t)
+
+	// Create a dummy request to pass to our problem response.
+	r, err := newRequest("GET", "/error", nil)
+	is.NoErr(err)
+
+	// Create a response recorder, which satisfied http.ResponseWriter, to record the response.
+	rr := httptest.NewRecorder()
+
+	// Respond with an error.
+	Error(rr, r, "Oops...", http.StatusInternalServerError)
+
+	// Check things.
+	is.Equal(rr.Code, http.StatusInternalServerError) // status code is correct.
+
+	type body struct {
+		Type   string `json:"type"`
+		Title  string `json:"title"`
+		Status int    `json:"status"`
+	}
+
+	expectedBody := body{
+		Type:   "about:blank",
+		Title:  "Oops...",
+		Status: http.StatusInternalServerError,
+	}
+	var actualBody body
+	err = json.Unmarshal(rr.Body.Bytes(), &actualBody)
+	is.NoErr(err)                      // actual body is json.
+	is.Equal(actualBody, expectedBody) // response body is correct.
+
+	d := getDetails(r)
+	is.True(d != nil)                                      // details exist.
+	is.Equal(d.StatusCode, http.StatusInternalServerError) // status is set on details.
+}

--- a/api/requestresponse_test.go
+++ b/api/requestresponse_test.go
@@ -112,7 +112,7 @@ func TestNotFoundResponse(t *testing.T) {
 
 	is := is.New(t)
 
-	// Create a dummy request to pass to our problem response.
+	// Create a dummy request to pass to our not found response.
 	r, err := newRequest("GET", "/not-found", nil)
 	is.NoErr(err)
 
@@ -154,7 +154,7 @@ func TestErrorResponse(t *testing.T) {
 
 	is := is.New(t)
 
-	// Create a dummy request to pass to our problem response.
+	// Create a dummy request to pass to our error response.
 	r, err := newRequest("GET", "/error", nil)
 	is.NoErr(err)
 

--- a/api/requestresponse_test.go
+++ b/api/requestresponse_test.go
@@ -37,6 +37,8 @@ func TestProblemResponse(t *testing.T) {
 	// Check things.
 	is.Equal(rr.Code, http.StatusTeapot) // status code is teapot.
 
+	is.Equal(rr.Header().Get("Content-Type"), "application/problem+json") // content-type is correct.
+
 	type body struct {
 		Type   string `json:"type"`
 		Title  string `json:"title"`
@@ -74,6 +76,8 @@ func TestProblemResponseWithExtras(t *testing.T) {
 
 	// Check things.
 	is.Equal(rr.Code, http.StatusTeapot) // status code is teapot.
+
+	is.Equal(rr.Header().Get("Content-Type"), "application/problem+json") // content-type is correct.
 
 	type body struct {
 		Type     string `json:"type"`
@@ -117,6 +121,8 @@ func TestNotFoundResponse(t *testing.T) {
 	// Check things.
 	is.Equal(rr.Code, 404) // status code is correct.
 
+	is.Equal(rr.Header().Get("Content-Type"), "application/problem+json") // content-type is correct.
+
 	type body struct {
 		Type   string `json:"type"`
 		Title  string `json:"title"`
@@ -154,6 +160,8 @@ func TestErrorResponse(t *testing.T) {
 
 	// Check things.
 	is.Equal(rr.Code, http.StatusInternalServerError) // status code is correct.
+
+	is.Equal(rr.Header().Get("Content-Type"), "application/problem+json") // content-type is correct.
 
 	type body struct {
 		Type   string `json:"type"`

--- a/api/requestresponse_test.go
+++ b/api/requestresponse_test.go
@@ -146,7 +146,7 @@ func TestNotFoundResponse(t *testing.T) {
 	d := getDetails(r)
 	is.True(d != nil) // details exist.
 	if d != nil {
-		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+		is.Equal(d.StatusCode, 404) // status is set on details.
 	}
 }
 
@@ -188,6 +188,6 @@ func TestErrorResponse(t *testing.T) {
 	d := getDetails(r)
 	is.True(d != nil) // details exist.
 	if d != nil {
-		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
+		is.Equal(d.StatusCode, http.StatusInternalServerError) // status is set on details.
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/julienschmidt/httprouter v1.3.0
+	github.com/matryer/is v1.3.0
 	github.com/prometheus/client_golang v1.6.0
 	github.com/segmentio/ksuid v1.0.2
 	go.uber.org/zap v1.15.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/matryer/is v1.3.0
+	github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721
 	github.com/prometheus/client_golang v1.6.0
 	github.com/segmentio/ksuid v1.0.2
 	go.uber.org/zap v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/matryer/is v1.3.0 h1:9qiso3jaJrOe6qBRJRBt2Ldht05qDiFP9le0JOIhRSI=
+github.com/matryer/is v1.3.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721 h1:ArxMo6jAOO2KuRsepZ0hTaH4hZCi2CCW4P9PV59HHH0=
+github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721/go.mod h1:jQyRpOpE/KbvPc0VKXjAqctYglwUO5W6zAcGcFfbvlo=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Description

Adds a function to respond to HTTP requests with an error body following the 'Problem Details for HTTP APIs RFC': https://tools.ietf.org/html/rfc7807.

This function is:
`func Problem(w http.ResponseWriter, r *http.Request, title, detail string, code int, extras ...ProblemExtra)`

The response that is returned follows this structure:
```
{
  "type": "about:blank", // can be overridden
  "title": "Problem title",
  "status": status_code,
  "detail": "Problem detail", // can be overridden
  "instance": "Problem instance" // an optional field
}
```

The optional/overriden fields are populated using the optional `ProblemExtra` arguments. There are helper functions available that return `ProblemExtra`s:
- `func WithType(t string) ProblemExtra`
- `func WithDetail(detail string) ProblemExtra`
- `func WithInstance(instance string) ProblemExtra`

It is possible to add any arbitrary data to the response, using `func WithFields(fields map[string]interface{})`.

Two more functions are added to 'mirror' the `net/http` package:
- `func NotFound(w http.ResponseWriter, r *http.Request, extras ...ProblemExtra)`
- `func Error(w http.ResponseWriter, r *http.Request, err string, code int, extras ...ProblemExtra)`

These both return a problem response, `NotFound` with a 404 status, and `Error` with the `err` string as the title.

### Questions/TODO
- [x] ~Should it be possible to add arbitrary data to the response as is possible in the RFC? What should the API for this be, if so?~ Yes, it should be possible.
- [x] ~Should `Error` use the `err` string as the title, or as the detail? If it's the detail, what should the title be set to in this case?~ The err string is the detail, the http status text is the title.

### Added Extras
- Tests 💃 
- Linting in CI 🔥 