### PR TITLE
v1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.27
+          version: v1.32
           only-new-issues: true

--- a/api/api.go
+++ b/api/api.go
@@ -15,7 +15,7 @@ type Endpoint struct {
 	// The HTTP Method of this endpoint.
 	Method string
 	// The URL Path of this endpoint. Should follow the format for
-	// paths specified by https://github.com/julienschmidt/httprouter.
+	// paths specified by https://github.com/dimfeld/httptreemux.
 	Path string
 	// The handler to invoke when a request for the given Method, Path is received
 	Handler http.Handler

--- a/api/cors.go
+++ b/api/cors.go
@@ -32,7 +32,7 @@ func CorsMW(c *cors.Cors) *CorsMiddleware {
 
 			defer func() {
 				// Set status code value on request details so other middlewares can access it.
-				if d := GetDetails(r); d != nil {
+				if d := getDetails(r); d != nil {
 					d.StatusCode = scrw.statusCode
 				}
 			}()

--- a/api/details.go
+++ b/api/details.go
@@ -14,8 +14,8 @@ type ctxKey int
 // keyDetails is how request details are stored and retrieved
 const keyDetails ctxKey = 1
 
-// Details represent state for each request
-type Details struct {
+// details represent state for each request
+type details struct {
 	Now         time.Time
 	RequestID   string
 	Method      string
@@ -24,10 +24,10 @@ type Details struct {
 	StatusCode  int
 }
 
-// SetDetails adds the required setails into the given request's context. The returned request should then be used.
+// SetDetails adds the required details into the given request's context. The returned request should then be used.
 func SetDetails(r *http.Request, path string, params map[string]string) *http.Request {
 
-	d := Details{
+	d := details{
 		Now:         time.Now(),
 		RequestID:   ksuid.New().String(), // TODO: Get from request to add some request tracing.
 		Method:      r.Method,
@@ -41,9 +41,9 @@ func SetDetails(r *http.Request, path string, params map[string]string) *http.Re
 	return r.WithContext(ctx)
 }
 
-// GetDetails returns any details found within the http.Request, or nil
-func GetDetails(r *http.Request) *Details {
-	v, ok := r.Context().Value(keyDetails).(*Details)
+// getDetails returns any details found within the http.Request, or nil
+func getDetails(r *http.Request) *details {
+	v, ok := r.Context().Value(keyDetails).(*details)
 	if !ok {
 		return nil
 	}
@@ -52,7 +52,7 @@ func GetDetails(r *http.Request) *Details {
 
 // URLParam returns the named parameter from the request's URL path.
 func URLParam(r *http.Request, name string) string {
-	d := GetDetails(r)
+	d := getDetails(r)
 	if d == nil {
 		return ""
 	}

--- a/api/details.go
+++ b/api/details.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/julienschmidt/httprouter"
 	"github.com/segmentio/ksuid"
 )
 
@@ -21,12 +20,12 @@ type Details struct {
 	RequestID   string
 	Method      string
 	RequestPath string
-	Params      httprouter.Params
+	Params      map[string]string
 	StatusCode  int
 }
 
 // SetDetails adds the required setails into the given request's context. The returned request should then be used.
-func SetDetails(r *http.Request, path string, params httprouter.Params) *http.Request {
+func SetDetails(r *http.Request, path string, params map[string]string) *http.Request {
 
 	d := Details{
 		Now:         time.Now(),
@@ -57,5 +56,5 @@ func URLParam(r *http.Request, name string) string {
 	if d == nil {
 		return ""
 	}
-	return d.Params.ByName(name)
+	return d.Params[name]
 }

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -26,6 +25,6 @@ func newTestRequest(method, path string, body io.Reader, matchedPath string) (*h
 	if err != nil {
 		return nil, err
 	}
-	r = SetDetails(r, matchedPath, httprouter.Params{})
+	r = SetDetails(r, matchedPath, map[string]string{})
 	return r, nil
 }

--- a/api/logging.go
+++ b/api/logging.go
@@ -14,7 +14,7 @@ func LogMW(logger *zap.SugaredLogger) Middleware {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				// Retrieve detail state of this request
-				d := GetDetails(r)
+				d := getDetails(r)
 				if d == nil {
 					// There's nothing more to do if we can't find the details.
 					return
@@ -38,7 +38,7 @@ func LogMW(logger *zap.SugaredLogger) Middleware {
 // fields. It should be used when logging from within a request handler, so that
 // those logs can be correlated.
 func LoggerFromRequest(r *http.Request, l *zap.SugaredLogger) *zap.SugaredLogger {
-	d := GetDetails(r)
+	d := getDetails(r)
 	if d == nil {
 		return l
 	}

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -39,7 +39,7 @@ func MetricsMW(reg prometheus.Registerer, endpoints []Endpoint) Middleware {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				// Retrieve detail state of this request
-				d := GetDetails(r)
+				d := getDetails(r)
 				if d == nil {
 					// There's nothing more to do if we can't find the details.
 					return

--- a/api/requestresponse.go
+++ b/api/requestresponse.go
@@ -40,7 +40,7 @@ func Respond(w http.ResponseWriter, r *http.Request, code int, data interface{})
 	}
 
 	// Set status code value on request details so other middlewares can access it
-	if d := GetDetails(r); d != nil {
+	if d := getDetails(r); d != nil {
 		d.StatusCode = code
 	}
 
@@ -60,7 +60,7 @@ func Respond(w http.ResponseWriter, r *http.Request, code int, data interface{})
 func Redirect(w http.ResponseWriter, r *http.Request, url string, code int) {
 
 	// Set status code value on request details so other middlewares can access it
-	if d := GetDetails(r); d != nil {
+	if d := getDetails(r); d != nil {
 		d.StatusCode = code
 	}
 

--- a/api/requestresponse_test.go
+++ b/api/requestresponse_test.go
@@ -47,7 +47,7 @@ func TestProblemResponse(t *testing.T) {
 	is.NoErr(err)                      // actual body is json.
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
-	d := GetDetails(r)
+	d := getDetails(r)
 	is.True(d != nil) // details exist.
 	if d != nil {
 		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
@@ -93,7 +93,7 @@ func TestProblemResponseWithExtras(t *testing.T) {
 	is.NoErr(err)                      // actual body is json.
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
-	d := GetDetails(r)
+	d := getDetails(r)
 	is.True(d != nil) // details exist.
 	if d != nil {
 		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
@@ -151,7 +151,7 @@ func TestProblemResponseWithFields(t *testing.T) {
 	is.NoErr(err)                      // actual body is json.
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
-	d := GetDetails(r)
+	d := getDetails(r)
 	is.True(d != nil) // details exist.
 	if d != nil {
 		is.Equal(d.StatusCode, http.StatusTeapot) // status is set on details.
@@ -195,7 +195,7 @@ func TestNotFoundResponse(t *testing.T) {
 	is.NoErr(err)                      // actual body is json.
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
-	d := GetDetails(r)
+	d := getDetails(r)
 	is.True(d != nil) // details exist.
 	if d != nil {
 		is.Equal(d.StatusCode, 404) // status is set on details.
@@ -239,7 +239,7 @@ func TestNotFoundWithDetailResponse(t *testing.T) {
 	is.NoErr(err)                      // actual body is json.
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
-	d := GetDetails(r)
+	d := getDetails(r)
 	is.True(d != nil) // details exist.
 	if d != nil {
 		is.Equal(d.StatusCode, 404) // status is set on details.
@@ -283,7 +283,7 @@ func TestErrorResponse(t *testing.T) {
 	is.NoErr(err)                      // actual body is json.
 	is.Equal(actualBody, expectedBody) // response body is correct.
 
-	d := GetDetails(r)
+	d := getDetails(r)
 	is.True(d != nil) // details exist.
 	if d != nil {
 		is.Equal(d.StatusCode, http.StatusInternalServerError) // status is set on details.
@@ -427,7 +427,7 @@ func TestRedirect(t *testing.T) {
 	Redirect(rr, r, "https://example.com", http.StatusPermanentRedirect)
 
 	// Check that the status is set in request details.
-	d := GetDetails(r)
+	d := getDetails(r)
 	is.True(d != nil) // details exists.
 	if d != nil {
 		is.Equal(d.StatusCode, http.StatusPermanentRedirect) // details contains correct status code.

--- a/api/server.go
+++ b/api/server.go
@@ -3,13 +3,13 @@ package api
 import (
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
+	"github.com/dimfeld/httptreemux/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
 type server struct {
-	router *httprouter.Router
+	router *httptreemux.TreeMux
 	logger *zap.SugaredLogger
 	mw     []Middleware
 }
@@ -19,7 +19,7 @@ func NewServer(addr string, logger *zap.SugaredLogger, a API) http.Server {
 
 	// Create our server
 	s := server{
-		router: httprouter.New(),
+		router: httptreemux.New(),
 		logger: logger,
 		mw:     make([]Middleware, 0), // Place for default middleware.
 	}
@@ -87,7 +87,7 @@ func (s *server) handle(method, path string, handler http.Handler, mw ...Middlew
 	handler = wrapMiddleware(s.mw, handler)
 
 	// Create the function to execute for each request
-	h := func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	h := func(w http.ResponseWriter, r *http.Request, params map[string]string) {
 
 		// Update request context with the required details to process the request
 		r = SetDetails(r, path, params)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dlmiddlecote/kit
+module github.com/dlmiddlecote/kit/v1
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dlmiddlecote/kit
 go 1.14
 
 require (
-	github.com/julienschmidt/httprouter v1.3.0
+	github.com/dimfeld/httptreemux/v5 v5.2.2
 	github.com/matryer/is v1.3.0
 	github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721
 	github.com/prometheus/client_golang v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dimfeld/httptreemux/v5 v5.2.2 h1:8JAUcuNrLbL5uwmvQ4lZVCjuQ/Ioojc+7VGt89aMElU=
+github.com/dimfeld/httptreemux/v5 v5.2.2/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -37,8 +39,6 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
Update router to be [httpreemux](https://github.com/dimfeld/httptreemux) to expand the path options. The routing rules are relaxed so that a single path segment may be a wildcard in one route and a static token in another. This router is slightly slower than the one removed, but the overhead should be negligible. See benchmarks [here](https://github.com/julienschmidt/go-http-routing-benchmark).

This package is now bumped to v1 because there is a public API change:
- `func SetDetails(r *http.Request, path string, params httprouter.Params) *http.Request` becomes `func SetDetails(r *http.Request, path string, params map[string]string) *http.Request`
- `func GetDetails` is removed from the public API
- `type Details struct` is removed from the public API